### PR TITLE
add `Sized` bound to `Trig` trait

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -130,7 +130,7 @@ pub trait Ops {
 }
 
 /// Trait of Trigonometry
-pub trait Trig {
+pub trait Trig: Sized {
     /// Sine
     fn sin(self) -> Self;
 


### PR DESCRIPTION
This is required to fix a forwards compatibility warning.
See #33242 for details.